### PR TITLE
Fix Tesseract language code to avoid missing traineddata

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ cp .env.example .env # preencha OPENAI_API_KEY
 npm run dev
 ```
 
+Por padrão, o OCR usa o idioma `por` (Português). Para outro idioma, defina a variável de ambiente `LANG` com o código Tesseract correspondente (por exemplo, `LANG=eng`).
+
 ## Build
 ```bash
 npm run dist

--- a/main.js
+++ b/main.js
@@ -58,7 +58,7 @@ async function pipeline() {
     }
     const pngBuffer = source.thumbnail.toPNG();
 
-    const lang = process.env.LANG || 'pt-BR';
+    const lang = process.env.LANG || 'por';
     const ocrText = await runOCR(pngBuffer, lang);
 
     const lines = ocrText.split('\n').map(l => l.trim()).filter(Boolean);

--- a/src/ocr.js
+++ b/src/ocr.js
@@ -1,6 +1,9 @@
 const Tesseract = require('tesseract.js');
 
-async function runOCR(pngBuffer, lang = 'pt-BR') {
+async function runOCR(pngBuffer, lang = 'por') {
+  if (lang === 'pt-BR') {
+    lang = 'por';
+  }
   const { data: { text } } = await Tesseract.recognize(pngBuffer, lang);
   return text;
 }


### PR DESCRIPTION
## Summary
- Default OCR language to `por` and alias `pt-BR` to `por`
- Document how to set LANG environment variable for different Tesseract codes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689f93be82988332acdae07bb20c7c60